### PR TITLE
Fork more to support django 1.11

### DIFF
--- a/ios_notifications/__init__.py
+++ b/ios_notifications/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-VERSION = '0.2'
+VERSION = '0.2.1'

--- a/ios_notifications/admin.py
+++ b/ios_notifications/admin.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
-try:
-    from django.conf.urls import patterns, url
-except ImportError:  # deprecated since Django 1.4
-    from django.conf.urls.defaults import patterns, url
+from django.conf.urls import url
 
 from django.contrib import admin
 from django.template.response import TemplateResponse
@@ -34,9 +31,8 @@ class NotificationAdmin(admin.ModelAdmin):
 
     def get_urls(self):
         urls = super(NotificationAdmin, self).get_urls()
-        notification_urls = patterns('',
-                                     url(r'^(?P<id>\d+)/push-notification/$', self.admin_site.admin_view(self.admin_push_notification),
-                                     name='admin_push_notification'),)
+        notification_urls = [url(r'^(?P<id>\d+)/push-notification/$', self.admin_site.admin_view(self.admin_push_notification),
+                                     name='admin_push_notification')]
         return notification_urls + urls
 
     def admin_push_notification(self, request, **kwargs):

--- a/ios_notifications/urls.py
+++ b/ios_notifications/urls.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
 
-try:
-    from django.conf.urls import patterns, url
-except ImportError:  # deprecated since Django 1.4
-    from django.conf.urls.defaults import patterns, url
-
+from django.conf.urls import url
 from .api import routes
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^device/$', routes.device, name='ios-notifications-device-create'),
     url(r'^device/(?P<token>\w+)/(?P<service__id>\d+)/$', routes.device, name='ios-notifications-device'),
-)
+]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ],
     install_requires=[
-        'Django>=1.3',
+        'Django>=1.8',
         'pyOpenSSL>=0.10',
         'django-fields>=0.2.2'
     ],


### PR DESCRIPTION
https://github.com/doordash/django-ios-notifications/pull/3 can be risky and we don't really need the changes. Just make it compatible w/ newer Django for now

@doordash/infrastructure 